### PR TITLE
Change watch and stream print behaviour and fix bug in echo output

### DIFF
--- a/scripts/commands/logs/index.md
+++ b/scripts/commands/logs/index.md
@@ -6,24 +6,27 @@ that uniquely identify a log group. E.g. Instead of having to write `/aws/codebu
 as the full log group name you can use `codebuild index bulk` to uniquely identify the group.
 If multiple log groups match it will fail and print the names of the matching groups.
 
-It will use `filter-log-events` from the `awscli` to regularly get new log events and print any events that 
+It will use `filter-log-events` from the `awscli` to regularly get new log events and print any events that
 haven't been seen before.
 
-This command is heavily inspired by the great [awslogs](https://github.com/jorgebastida/awslogs) 
-tool by [jorgebastida](https://github.com/jorgebastida). The main difference compared to awslogs (apart from being 
+By default the command will watch regularly for new messages and print them to the console.
+This can be stopped with ctrl-c.
+
+This command is heavily inspired by the great [awslogs](https://github.com/jorgebastida/awslogs)
+tool by [jorgebastida](https://github.com/jorgebastida). The main difference compared to awslogs (apart from being
 written in bash and not python) is that it supports new log-streams coming in while logs are being watched and
 some UX improvements like matching log-groups with substrings.
 
 ## Options:
 
 * `-G`: Remove the log group name from the output
-* `-S`: Remove the stream name from the log output
-* `-f`: Filter log events you want to see. 
+* `-S`: Add the stream name to the log output
+* `-f`: Filter log events you want to see.
         See [Filter Patter Syntax](http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)
-* `-s`: Start time to search from. Uses Gnu Date which supports a complex date syntax. Automatically converts to UTC. 
-        (e.g. "now", "-5minutes", "-3days", "Monday", "15:30", "2017-01-01T06:30"). 
+* `-s`: Start time to search from. Uses Gnu Date which supports a complex date syntax. Automatically converts to UTC.
+        (e.g. "now", "-5minutes", "-3days", "Monday", "15:30", "2017-01-01T06:30").
         The current implementation doesn't allow for whitespace in the dates.
-* `-e`: End time to search to. Same syntax as start time before.
+* `-e`: End time to search to. Same syntax as start time before. Will disable log watching (implicit -w argument)
 * `-t`: Print timestamp for log message
 * `-i`: Print ingestion time for log message
-* `-w`: Watch regularly for new messages and print them to the console. Can be stopped with ctrl-c.
+* `-w`: Do not watch the log and end after getting the first set of log messages

--- a/tests/commands/logs/index.bats
+++ b/tests/commands/logs/index.bats
@@ -18,7 +18,7 @@ setup(){
 
 @test "getting log messages" {
     # Default Logging Setup
-    run awsinfo logs InfoTestLogGroup $(stack_name)
+    run awsinfo logs -w -S InfoTestLogGroup $(stack_name)
     assert_success
     echo "$output"
     assert_output -p "TestMessage-1"
@@ -28,7 +28,7 @@ setup(){
     assert_output -p "AWSInfoTestLogGroup"
 
     # Without LogStream
-    run awsinfo logs -S InfoTestLogGroup $(stack_name)
+    run awsinfo logs -w InfoTestLogGroup $(stack_name)
     assert_success
     echo "$output"
     assert_output -p "TestMessage"
@@ -37,7 +37,7 @@ setup(){
     refute_output -p "$LOG_STREAM_NAME_2"
 
     # Without LogGroup
-    run awsinfo logs -G InfoTestLogGroup $(stack_name)
+    run awsinfo logs -w -G -S InfoTestLogGroup $(stack_name)
     assert_success
     echo "$output"
     refute_line -n 1 -p '$(stack_name)-AWSInfoTestLogGroup'
@@ -45,13 +45,13 @@ setup(){
     assert_line -n 1 -p "TestMessage-1"
 
     # Checking for log groups test message
-    run awsinfo logs -G -S InfoTestLogGroup $(stack_name)
+    run awsinfo logs -w -G InfoTestLogGroup $(stack_name)
     assert_success
     echo "$output"
     assert_line -n 0 -e "^.*Selected LogGroup $(stack_name)-AWSInfoTestLogGroup-.*$"
 
     # Filtering messages
-    run awsinfo logs -f "TestMessage-1" InfoTestLogGroup $(stack_name)
+    run awsinfo logs -w -S -f "TestMessage-1" InfoTestLogGroup $(stack_name)
     assert_success
     echo "$output"
     assert_output -p "TestMessage-1"
@@ -60,7 +60,7 @@ setup(){
     refute_output -p "$LOG_STREAM_NAME_2"
     refute_output -p "TestMessage-2"
 
-    run awsinfo logs  -e now -s -10minutes InfoTestLogGroup $(stack_name)
+    run awsinfo logs -e now -s -10minutes -S InfoTestLogGroup $(stack_name)
     assert_success
     echo "$output"
     assert_output -p "TestMessage-1"


### PR DESCRIPTION
Watching is enabled by default and streams are not shown.
Echo didn't have "" surrounding the output which mean log messages
were interpreted as commands